### PR TITLE
0.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A basic implementation of Floating Action Button pattern as seen on Material Des
 
 ### Usage
 
-See demo, at this point latest version is `0.0.4`
+See demo, at this point latest version is `0.0.5`
 
 ```groovy
 compile 'com.telly:floatingaction:(insert latest version)'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.0.4
-VERSION_CODE=4
+VERSION_NAME=0.0.5
+VERSION_CODE=5
 GROUP=com.telly
 
 POM_DESCRIPTION=A basic implementation of Floating Action pattern


### PR DESCRIPTION
- Allows to show/hide without animating
- Allows to provide a parent instead of just an id, useful when using within fragments
- Fixes corner case when view has no height yet, this happens if a hide/show call is made right after creating a new instance
- Fixes builder not returning its own instance for anim\* methods
